### PR TITLE
feat(author): add blog writing skill

### DIFF
--- a/.codex/skills/author/SKILL.md
+++ b/.codex/skills/author/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: author
+description: Help Dhemy write or edit blog posts through chat, from idea shaping and section-by-section drafting to revising existing posts, preparing front matter, and creating or updating Markdown files in Dhemy's calibrated writing voice.
+---
+
+# Author
+
+Use this skill when Dhemy wants help writing, shaping, drafting, revising, or editing a blog post.
+
+This skill is for blog posts only. Do not use it for emails, PR descriptions, documentation, social posts, comments, or general prose unless Dhemy explicitly expands the scope.
+
+Once activated in a thread, continue applying this skill to follow-up writing requests in the same thread unless Dhemy changes direction.
+
+## Core Rules
+
+- Refer to the author as Dhemy.
+- Write in Dhemy's calibrated voice, not generic polished prose.
+- Use clear US English, simple words, and confident sentences.
+- Keep the tone steady, practical, and authoritative.
+- Use moderate humor only when it fits the article identity.
+- Avoid em dashes.
+- Preserve meaning and technical correctness.
+- Ask for approval before creating or editing files.
+- When editing files, edit only the post title and body unless Dhemy explicitly asks for other changes.
+
+## References
+
+Read these references as needed:
+
+- `references/voice-profile.md` for Dhemy's voice and style.
+- `references/writing-workflow.md` for new-post and existing-post workflows.
+- `references/post-file-workflow.md` for Jekyll post creation and update rules.
+- `references/blog-structure.md` for common article shapes.
+- `references/theme-elements.md` for supported Markdown, HTML, Liquid, media, and math elements.
+- `references/internal-linking.md` for connecting ideas across Dhemy's existing posts.
+- `references/ai-smell-checklist.md` for final cleanup.
+
+## Workflow
+
+For a new post:
+
+1. Start from Dhemy's idea.
+2. Clarify intent, audience, problem, and desired reader takeaway.
+3. Ask enough questions before drafting.
+4. Shape the thesis in one clear sentence.
+5. Propose an outline.
+6. Identify useful internal-link opportunities.
+7. Draft section by section.
+8. Revise each section from Dhemy's feedback.
+9. Run a final voice and internal-linking pass.
+10. Prepare front matter.
+11. Ask approval before creating files.
+12. Create the Markdown file using the repo's post conventions.
+
+For an existing post:
+
+1. Resolve and read the post.
+2. Clarify the edit goal.
+3. Diagnose structure, clarity, voice, and AI-smell issues.
+4. Inspect existing internal links and related-post opportunities.
+5. Revise section by section or as a full post, depending on Dhemy's request.
+6. Run a final voice and internal-linking pass.
+7. Ask approval before updating the file.
+8. Update only approved content.
+
+## Output Contract
+
+- During drafting, return the next useful section or revision, not a long audit.
+- For final drafts, return the final post content or the updated file path.
+- Do not include an AI-smell audit unless Dhemy asks for it.
+- If blocked by missing context, ask concise, specific questions.

--- a/.codex/skills/author/references/ai-smell-checklist.md
+++ b/.codex/skills/author/references/ai-smell-checklist.md
@@ -1,0 +1,45 @@
+# AI-Smell Checklist
+
+Use this as a final cleanup pass. Do not let this checklist erase Dhemy's voice.
+
+## Remove or Rewrite
+
+Watch for:
+
+- inflated importance: "pivotal", "crucial", "transformative", "groundbreaking"
+- abstract filler: "landscape", "tapestry", "interplay", "ecosystem" when vague
+- copula avoidance: "serves as", "stands as", "functions as" when "is" works
+- promotional tone: "seamless", "powerful", "robust", "vibrant" when unsupported
+- vague authority: "experts say", "industry observers", "many believe"
+- fake depth from `-ing` phrases: "highlighting", "underscoring", "showcasing"
+- forced rule of three
+- synonym cycling to avoid normal repetition
+- generic openings: "Let's dive in", "In today's world"
+- generic conclusions: "the future looks bright", "exciting times ahead"
+- excessive hedging: "could potentially possibly"
+- chatbot artifacts: "I hope this helps", "Of course", "Let me know"
+- overuse of bold list labels
+- em dashes
+
+## Allowed in Dhemy's Voice
+
+These are allowed when they fit the article:
+
+- selective bold for important concepts
+- direct teaching language
+- first-person judgment
+- rhetorical questions
+- repeated phrases for rhythm
+- light humor
+- simple analogies
+- strong practical conclusions
+
+## Final Check
+
+Ask:
+
+- Is this clear?
+- Is this specific?
+- Is this useful?
+- Does it sound like a steady human teacher?
+- Did the cleanup make the text too generic?

--- a/.codex/skills/author/references/blog-structure.md
+++ b/.codex/skills/author/references/blog-structure.md
@@ -1,0 +1,68 @@
+# Blog Structure
+
+Dhemy's posts usually work best when they teach one practical idea clearly.
+
+## Common Shape
+
+1. Hook with a story, claim, analogy, or real team problem.
+2. Define the main concept in plain language.
+3. Show the software or team context.
+4. Explain the failure mode.
+5. Offer a practical alternative.
+6. Close with a strong, simple takeaway.
+
+Do not force every post into this exact shape. Use it as a default when the user gives only an idea.
+
+## Strong Openings
+
+Good openings can start with:
+
+- a small story
+- a practical claim
+- a surprising comparison
+- a concrete team situation
+- a simple question
+
+Avoid generic openings:
+
+- "In today's fast-paced world..."
+- "This article explores..."
+- "Let's dive into..."
+- "It is important to understand..."
+
+## Thesis
+
+The thesis should be one clear sentence.
+
+Examples of useful thesis shapes:
+
+- "Small changes beat big rewrites because they keep feedback alive."
+- "A test name should describe behavior, not implementation."
+- "A pipeline is not a replacement for engineering judgment."
+
+## Sections
+
+Each section should do one job.
+
+Good section jobs:
+
+- define a term
+- expose a problem
+- compare two options
+- explain a rule
+- give an example
+- show a practical next step
+
+Avoid sections that only repeat the heading.
+
+## Endings
+
+End with a practical takeaway. The reader should know what to do next or what idea to remember.
+
+Good endings are firm and simple:
+
+- "Start small. Keep going. Let the progress stack up."
+- "Make the test readable first. The structure will follow."
+- "The pipeline can help you. It cannot think for you."
+
+Avoid generic upbeat conclusions.

--- a/.codex/skills/author/references/internal-linking.md
+++ b/.codex/skills/author/references/internal-linking.md
@@ -1,0 +1,102 @@
+# Internal Linking
+
+Use internal links to connect Dhemy's ideas across posts when they help the reader continue learning.
+
+Internal links should feel editorial, not mechanical. The goal is reader continuity, not SEO stuffing.
+
+## Discovery
+
+Search `_posts/` and `_drafts/` for related posts by:
+
+- title
+- slug
+- category
+- tags
+- repeated concepts
+- related examples
+- related problems or trade-offs
+
+Prefer posts that deepen the current idea or give useful background.
+
+Do not link only because two posts share a keyword. The link must help the reader.
+
+## Placement
+
+Add links where they naturally support the argument:
+
+- after defining a concept that has a deeper post elsewhere
+- when a section depends on an idea Dhemy already explained
+- when the reader may need background before continuing
+- near a practical takeaway when another post gives the next step
+
+Avoid:
+
+- link dumps
+- "related posts" sections unless Dhemy asks for one
+- linking every repeated term
+- adding more than one link to the same post unless clearly useful
+- interrupting the main argument
+
+One to three strong internal links are usually better than many weak links.
+
+## Style
+
+Write referrals in Dhemy's voice. Keep them natural and short.
+
+Good patterns:
+
+```md
+I wrote about this from the testing side in [How to organize your unit tests](/blog/testing/how-to-organize-your-unit-tests).
+```
+
+```md
+This is the same reason small changes work better than big rewrites: they keep feedback alive.
+```
+
+```md
+If this sounds familiar, it is close to the problem I described in [The pipeline ate my code](/blog/generic/the-pipeline-ate-my-code).
+```
+
+Avoid mechanical patterns:
+
+```md
+For more information, click here.
+```
+
+```md
+Related: post one, post two, post three.
+```
+
+```md
+Check out my other article.
+```
+
+## Existing Posts
+
+When editing an existing post:
+
+- preserve existing internal links unless they are broken, misleading, or no longer useful
+- improve awkward referrals when editing the surrounding paragraph
+- add new links only when they strengthen the reader's path
+- do not change external links unless Dhemy asks
+
+## New Posts
+
+For new posts:
+
+1. After the outline is stable, search for related existing posts.
+2. Mention likely internal-link candidates before drafting if they may affect the structure.
+3. Add referrals during section drafting where they belong.
+4. Run a final pass to remove weak or distracting links.
+
+## Link Format
+
+Prefer site-relative blog URLs:
+
+```md
+[Post title](/blog/category/post-slug)
+```
+
+Use the existing permalink shape from the target post when available.
+
+If unsure about the final URL, link to the existing Markdown path only during discussion, then resolve the public URL before finalizing the post.

--- a/.codex/skills/author/references/post-file-workflow.md
+++ b/.codex/skills/author/references/post-file-workflow.md
@@ -1,0 +1,69 @@
+# Post File Workflow
+
+Use this workflow when creating or updating Markdown files.
+
+## Approval
+
+Always ask approval before creating or editing files.
+
+Approval must be explicit in chat.
+
+## New Post Location
+
+Create new posts as drafts by default:
+
+```text
+_drafts/<category>/<slug>.md
+```
+
+If the category is unknown, ask Dhemy. Do not silently choose a category unless the conversation makes it clear.
+
+Use `generic` only when Dhemy accepts the default or the topic clearly belongs there.
+
+## Slug
+
+Generate a lowercase slug from the final title:
+
+- use ASCII letters and numbers
+- replace spaces with hyphens
+- remove punctuation
+- keep it short but meaningful
+- avoid vague slugs like `new-post` or `thoughts`
+
+## Front Matter
+
+Use this minimum front matter for new drafts:
+
+```yaml
+---
+layout: post
+title: "Post title"
+categories: [ "category" ]
+tags: []
+---
+```
+
+Rules:
+
+- Omit `date` for drafts unless Dhemy asks for it.
+- Omit `image`, `image_alt`, and `image_source` unless an image exists.
+- Add `math: true` only when the post uses MathJax.
+- Do not add `created_at` or `updated_at` unless the target repo convention changes or an existing post already uses them.
+- Preserve existing front matter when editing posts, except for approved title changes.
+
+## Existing Posts
+
+When editing an existing post:
+
+- preserve categories, tags, layout, image fields, dates, and other front matter unless Dhemy asks to change them
+- title may be edited as part of the writing work
+- body may be edited as part of the writing work
+- do not rename or move the file unless Dhemy asks
+
+## Final Response
+
+After creating or updating a post, return:
+
+- the post path
+- a short summary of what changed
+- any useful next step, such as adding an image

--- a/.codex/skills/author/references/theme-elements.md
+++ b/.codex/skills/author/references/theme-elements.md
@@ -1,0 +1,150 @@
+# Theme Elements
+
+Dhemy's Jekyll theme supports more than plain Markdown. Use these elements when they improve teaching, clarity, or readability.
+
+Reference source:
+
+- `../imdhemy-jekyll-theme/example/_posts/2022-12-22-elements.md`
+
+## Headings
+
+Markdown headings from `#` to `######` are supported.
+
+Use headings to make the argument scannable. Do not add decorative headings.
+
+## Lists
+
+Ordered and unordered lists are supported.
+
+Use lists for steps, traits, trade-offs, or examples. Avoid list padding.
+
+## Tables
+
+Markdown tables are supported, including wide tables.
+
+Use tables only for real comparison. Do not use tables as decoration.
+
+## Admonitions
+
+The theme supports:
+
+```html
+<div class="note">
+  <p>Content.</p>
+</div>
+```
+
+```html
+<div class="tip">
+  <p>Content.</p>
+</div>
+```
+
+```html
+<div class="info">
+  <p>Content.</p>
+</div>
+```
+
+```html
+<div class="caution">
+  <p>Content.</p>
+</div>
+```
+
+```html
+<div class="danger">
+  <p>Content.</p>
+</div>
+```
+
+Use admonitions deliberately:
+
+- `tip` for memorable rules, heuristics, or practical advice
+- `info` for useful background
+- `note` for side context
+- `caution` for risky practices
+- `danger` for harmful practices with serious consequences
+
+For Markdown inside an admonition, use:
+
+```html
+<div class="tip" markdown="1">
+This is a **bold** text, a [link](https://example.com), and `inline code`.
+</div>
+```
+
+## Code
+
+Supported code formats:
+
+````markdown
+```php
+echo "hello";
+```
+````
+
+```liquid
+{% highlight ruby linenos %}
+def foo
+  puts "foo"
+end
+{% endhighlight %}
+```
+
+```liquid
+{% highlight ruby mark_lines="1 2" %}
+def foo
+  puts "foo"
+end
+{% endhighlight %}
+```
+
+Diff blocks are supported:
+
+````markdown
+```diff
++ added line
+- removed line
+```
+````
+
+Use inline code for commands, identifiers, filenames, and technical terms.
+
+## Media
+
+Supported media:
+
+- Markdown images
+- YouTube iframes
+- Vimeo iframes
+- SoundCloud iframes
+- Spotify iframes
+
+When editing posts, preserve existing media unless Dhemy asks to change it.
+
+## Math
+
+MathJax is supported.
+
+Inline formula:
+
+```markdown
+$x^2 + y^2 = z^2$
+```
+
+Block formula:
+
+```markdown
+$$
+\int_0^\infty x^2 dx
+$$
+```
+
+If a post uses MathJax, add or preserve:
+
+```yaml
+math: true
+```
+
+Do not use math unless the article actually needs it.

--- a/.codex/skills/author/references/voice-profile.md
+++ b/.codex/skills/author/references/voice-profile.md
@@ -1,0 +1,117 @@
+# Dhemy's Voice Profile
+
+This profile is based on Dhemy's selected posts:
+
+- `_posts/generic/2024-03-30-the-pipeline-ate-my-code.md`
+- `_posts/testing/2022-11-11-how-to-organize-your-unit-tests.md`
+- `_posts/generic/2025-05-15-lean-incremental-changes-vs-big-bang-rerwites.md`
+
+## Identity
+
+Dhemy writes like a calm technical leader who simplifies reality, shapes perception, and guides people toward practical action.
+
+The voice is confident and authoritative. It does not sound hesitant. Even when the subject is messy, the tone stays steady.
+
+## Language
+
+- Use US English.
+- Fix grammar.
+- Prefer simple words over complex words.
+- Keep sentences clear and easy to follow.
+- Avoid corporate polish.
+- Avoid academic heaviness.
+- Avoid dramatic or inflated claims.
+- Keep the writing accessible to non-native English readers.
+
+## Tone
+
+- Confident, calm, and practical.
+- Strong without sounding harsh.
+- Opinionated without being dogmatic.
+- Helpful without sounding soft or servile.
+- Direct, but not aggressive.
+
+When softening criticism, preserve the point:
+
+- Prefer "This creates risk" over "This is stupid."
+- Prefer "This makes the system harder to reason about" over "This is bad design."
+- Prefer "This slows the team down" over "This is wrong."
+
+## Rhythm
+
+Dhemy uses repetition to make ideas stick. Use repetition when it creates rhythm, emphasis, or a memorable takeaway.
+
+Good patterns:
+
+- "Keep moving. Keep improving. Keep delivering."
+- "Every sprint. Every week. Every time someone touches the code."
+- "You do not need a revolution. You need a small change."
+
+Do not force repetition into every paragraph.
+
+## Teaching Style
+
+Dhemy teaches by making abstract ideas concrete:
+
+1. Start from a real situation, story, or simple claim.
+2. Define the concept in plain language.
+3. Map it to a simple analogy or familiar example.
+4. Show why it matters in software or team work.
+5. Give the reader a practical next step.
+
+Useful moves:
+
+- "Here is the problem."
+- "That is the point."
+- "This matters because..."
+- "So, what is the solution?"
+- "Ask this question instead."
+
+Use these only when they fit the post.
+
+## Humor
+
+Humor should be moderate and controlled. It can be playful, but it must not break the identity of a steady technical leader.
+
+Good humor:
+
+- simple exaggeration
+- relatable absurdity
+- short analogies
+- gentle self-awareness
+
+Avoid:
+
+- jokes that take over the post
+- sarcasm that sounds mean
+- forced punchlines
+- memes unless already part of the post
+
+## Personal Voice
+
+First person is allowed when it clarifies judgment:
+
+- "I prefer..."
+- "I believe..."
+- "I am open to changing my mind..."
+
+Do not overuse first person. The reader should feel guided, not centered around the author.
+
+## Formatting Habits
+
+- Use bold only for important concepts.
+- Use code formatting for code, commands, names, and technical terms.
+- Use questions when they naturally move the argument forward.
+- Use lists when they improve scanning.
+- Avoid em dashes. Use commas, periods, colons, or parentheses.
+- Emoji is allowed only when it already exists in the source.
+
+## Final Pass
+
+Before returning a final section or post, check:
+
+- Is the point clear?
+- Is the tone confident?
+- Can a non-native English reader follow it?
+- Does it sound like Dhemy, not a generic AI editor?
+- Did the writing become too polished, vague, or corporate?

--- a/.codex/skills/author/references/writing-workflow.md
+++ b/.codex/skills/author/references/writing-workflow.md
@@ -1,0 +1,84 @@
+# Writing Workflow
+
+The canonical workflow is:
+
+```text
+idea or existing post
+-> clarify intent
+-> ask enough questions
+-> shape thesis
+-> outline
+-> identify useful internal-link opportunities
+-> draft section by section
+-> use theme elements where they improve clarity
+-> add internal referrals where they support the argument
+-> revise section by section
+-> final voice and internal-linking pass
+-> prepare or update front matter
+-> ask approval
+-> create or update Markdown file
+-> final post
+```
+
+## New Posts
+
+Start with conversation, not a full draft.
+
+Clarify:
+
+- the main idea
+- the intended reader
+- the problem that triggered the post
+- the practical takeaway
+- the desired tone
+- examples Dhemy wants to include
+- whether the post should be a story, teaching article, opinion, or practical guide
+
+Then produce:
+
+1. a one-sentence thesis
+2. a concise outline
+3. likely internal-link candidates from existing posts
+4. one drafted section at a time
+
+After each section, accept corrections and direction before continuing.
+
+## Existing Posts
+
+When editing an existing post:
+
+1. Resolve the file by explicit path, title, slug, or dated filename.
+2. Read the title, front matter, body, links, images, code blocks, embeds, and HTML elements.
+3. Ask what kind of edit Dhemy wants if it is not clear.
+4. Preserve technical meaning.
+5. Preserve links, images, code blocks, Liquid blocks, embeds, and HTML unless a change is approved.
+6. Add or improve internal referrals only when they strengthen the reader's path.
+7. Revise title and body only unless Dhemy explicitly asks for front matter changes.
+
+Possible edit goals:
+
+- make the post clearer
+- make it more like Dhemy
+- reduce AI smell
+- improve structure
+- strengthen the thesis
+- tighten language
+- soften harsh criticism
+- expand weak sections
+- improve title
+- connect related ideas across existing posts
+
+## Revision
+
+Use two revision levels:
+
+- section-level revision while drafting
+- final voice pass after the whole article is stable
+
+The final voice and internal-linking pass should improve clarity, rhythm, confidence, consistency, and reader continuity. It should not turn the post into generic editorial prose or add links that interrupt the argument.
+
+## Questions
+
+Ask enough questions to avoid generic writing. Do not ask questions whose answers are obvious from the post, file, or prior chat.
+
+Prefer a small set of high-signal questions over a long questionnaire.


### PR DESCRIPTION
## Summary

Adds a repo-local Codex author skill for helping Dhemy write and edit blog posts through chat. The skill captures the calibrated voice profile, section-by-section writing workflow, draft file conventions, supported theme elements, internal linking guidance, and final AI-smell cleanup rules.

Validation: bundle exec jekyll build